### PR TITLE
Fix yank in ITerm2

### DIFF
--- a/functions/fish_helix_command.fish
+++ b/functions/fish_helix_command.fish
@@ -374,8 +374,9 @@ function __fish_helix_yank
     set -l cursor (commandline -C)
     commandline -f kill-selection yank backward-char
 
-    for i in (seq $cursor (math $end - 2))
+    while test $cursor -lt (math $end - 2)
         commandline -f backward-char
+        set cursor (commandline -C)
     end
 end
 


### PR DESCRIPTION
In ITerm2 on MacOS, `__fish_helix_yank` reduces the selection size by 2. I don't understand the underlying cause.

This PR fixes this behaviour.